### PR TITLE
[ADD] SecurityConfig

### DIFF
--- a/src/main/kotlin/org/oooc/kry/global/SecurityConfig.kt
+++ b/src/main/kotlin/org/oooc/kry/global/SecurityConfig.kt
@@ -1,0 +1,12 @@
+package org.oooc.kry.global
+
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+
+@EnableWebSecurity
+class SecurityConfig(): WebSecurityConfigurerAdapter() {
+    override fun configure(http: HttpSecurity) {
+        http.csrf().disable()
+    }
+}


### PR DESCRIPTION
- [ ] 성능 개선
- [ ] 버그 픽스
- [ ] 기능 수정
- [x] 새로운 기능
- [ ] 리팩토링

## 무엇을
SecurityConfig 클래스 추가

## 왜
Spring Security 디폴트 설정은 CSRF Enabled 상태이므로 Post 요청시 403 Forbidden 응답이 리턴되는 현상이 있습니다.
따라서 CSRF를 일시적으로 disable 하였습니다.
