### PR TITLE
[UPDATE] set server.error.include-stacktrace to "never"

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: none
+
+server:
+  error:
+    include-stacktrace: never


### PR DESCRIPTION
- [ ] 성능 개선
- [ ] 버그 픽스
- [x] 기능 수정
- [ ] 새로운 기능
- [ ] 리팩토링

## 무엇을

application.yml 파일에 server.error.include-stacktrace: never 설정을 추가했습니다.

## 왜

기존 방식대로라면 예외 핸들링 시 json 응답에 server log 가 "trace" 키에 포함되어 응답됩니다.
해당 로그는 개발자가 서버에서 확인할 수 있는 로그이기도 하고 
클라이언트 단에 공개되지 않는게 바람직하다고 판단되어 변경했습니다.

